### PR TITLE
always remove key addedParameters

### DIFF
--- a/lib/map-metadata-to-operation.js
+++ b/lib/map-metadata-to-operation.js
@@ -186,6 +186,7 @@ function getResponseDescription(code) {
 }
 
 function addCommonParameters(metadata, operation, stateCommon) {
+    delete operation.addedParameters;
     if (!metadata.common) {
         return;
     }
@@ -197,7 +198,6 @@ function addCommonParameters(metadata, operation, stateCommon) {
     addCommonParametersOfType(metadata.common.parameters.query, 'query', stateCommon, operation);
     addCommonParametersOfType(metadata.common.parameters.formData, 'formData', stateCommon, operation);
     addCommonParametersOfType(metadata.common.parameters.path, 'path', stateCommon, operation);
-    delete operation.addedParameters;
 }
 
 function addMetadataParameters(metadata, operation) {


### PR DESCRIPTION
Because swagger says that this is not a valid key to have in your swagger config.