### PR TITLE
Fix bug when compiling an initialised express Router

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,9 @@ module.exports = {
  */
 function compile() {
     ensureInitialised('compile');
+    if (state.app.name === 'router') {
+        state.app = { _router: state.app };
+    }
     if (!state.app._router) {
         throw new Error("app._router was null, either your app is not an express app, or you have called compile before adding at least one route");
     }


### PR DESCRIPTION
When using Express Router to initialise swagger-spec-express, the compile function would always throw the `app._router was null, either your app is not an express app, or you have called compile before adding at least one route` error.