### PR TITLE
Added types definition

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,66 @@
+import { Express } from 'express-serve-static-core';
+
+export interface IInitializeOptions {
+    document?: { [key: string]: any };
+    title?: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: {
+        name?: string;
+        url?: string;
+        email?: string;
+    };
+    licence?: {
+        name?: string;
+        url?: string;
+    };
+    version?: string;
+    host?: string;
+    basePath?: string;
+    schemes?: string[];
+    consumes?: string[];
+    produces?: string[];
+    paths?: { [key: string]: any };
+    definitions?: { [key: string]: any };
+    parameters?: { [key: string]: any };
+    responses?: { [key: string]: any };
+    securityDefinitions?: { [key: string]: any };
+    security?: { [key: string]: any };
+    defaultSecurity?: string | string[];
+    tags?: {
+        name?: string;
+        description?: string;
+        externalDocs?: {
+            description?: string;
+            url: string;
+        }
+    };
+    externalDocs?: {
+        description?: string
+        url: string;
+    }
+}
+
+export namespace common {
+  function addModel(model: any, inputOptions: any): void;
+  function addResponse(response: any, options: any): void;
+  function addResponseHeader(responseHeader: any, options: any): void;
+  function addTag(tag: any, options: any): void;
+  namespace parameters {
+    function addBody(body: any, options: any): void;
+    function addFormData(formData: any, options: any): void;
+    function addHeader(header: any, options: any): void;
+    function addPath(path: any, options: any): void;
+    function addQuery(query: any, options: any): void;
+  }
+}
+export function compile(): void;
+
+export function initialise(app: Express, options: IInitializeOptions): void;
+export function initialize(app: Express, options: IInitializeOptions): void;
+
+export function json(): any;
+export function reset(): void;
+export function swaggerise(item: any): void;
+export function swaggerize(item: any): void;
+export function validate(): any;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -50,16 +50,16 @@ interface IValid {
 interface JsonObject { [key: string]: any; }
 
 export namespace common {
-  function addModel(model: any, inputOptions: any): void;
-  function addResponse(response: any, options: any): void;
-  function addResponseHeader(responseHeader: any, options: any): void;
-  function addTag(tag: any, options: any): void;
+  function addModel(model: any, inputOptions?: any): void;
+  function addResponse(response: any, options?: any): void;
+  function addResponseHeader(responseHeader: any, options?: any): void;
+  function addTag(tag: any, options?: any): void;
   namespace parameters {
-    function addBody(body: any, options: any): void;
-    function addFormData(formData: any, options: any): void;
-    function addHeader(header: any, options: any): void;
-    function addPath(path: any, options: any): void;
-    function addQuery(query: any, options: any): void;
+    function addBody(body: any, options?: any): void;
+    function addFormData(formData: any, options?: any): void;
+    function addHeader(header: any, options?: any): void;
+    function addPath(path: any, options?: any): void;
+    function addQuery(query: any, options?: any): void;
   }
 }
 export function compile(): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -49,6 +49,14 @@ interface IValid {
 
 interface JsonObject { [key: string]: any; }
 
+export interface ISwaggerizedExpress extends Express {
+    describe: any;
+}
+
+export interface ISwaggerizedRouter extends Router {
+    describe: any;
+}
+
 export namespace common {
   function addModel(model: any, inputOptions?: any): void;
   function addResponse(response: any, options?: any): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,6 @@
-import { Express } from 'express-serve-static-core';
+import { Express, Router } from 'express-serve-static-core';
 
-export interface IInitializeOptions {
+interface IInitializeOptions {
     document?: { [key: string]: any };
     title?: string;
     description?: string;
@@ -41,6 +41,14 @@ export interface IInitializeOptions {
     }
 }
 
+interface IValid {
+    valid: boolean;
+    errors: object[];
+    message: string;
+}
+
+interface JsonObject { [key: string]: any; }
+
 export namespace common {
   function addModel(model: any, inputOptions: any): void;
   function addResponse(response: any, options: any): void;
@@ -59,8 +67,8 @@ export function compile(): void;
 export function initialise(app: Express, options: IInitializeOptions): void;
 export function initialize(app: Express, options: IInitializeOptions): void;
 
-export function json(): any;
+export function json(): JsonObject;
 export function reset(): void;
-export function swaggerise(item: any): void;
-export function swaggerize(item: any): void;
-export function validate(): any;
+export function swaggerise(item: Express | Router): void;
+export function swaggerize(item: Express | Router): void;
+export function validate(): IValid;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.12",
   "description": "Allows you to programatically annotate your express routes with swagger info and then generate and validate your json spec file",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "mocha": "mocha --full-trace test/**/*.js",
     "lint": "eslint \"lib/**/*.js\" \"test/**/*.js\"",


### PR DESCRIPTION
How do I use this revision (typescript):

```typescript
import * as express from 'express';
import * as swagger from 'swagger-spec-express';
import * as swaggerUi from 'swagger-ui-express';

const app = express() as swagger.ISwaggerizedExpress;
swagger.swaggerize(app);

swagger.initialize(app, {
  title: 'API Title',
  version: '1.0.0'
});

swagger.common.parameters.addQuery({
  name: 'query',
  description: '',
  required: true,
  type: 'string'
});

app.get('/search', (req, res) => {
  const { query } = req.query;

  res.status(200).json(query);
}).describe({
  responses: {
    200: {
      description: 'Okay'
    }
  },
  tags: ['Search'],
  common: {
    parameters: {
      query: ['query']
    }
  }
});

swagger.compile();

app.use('/', swaggerUi.serve);
app.get('/', swaggerUi.setup(swagger.json()));

app.listen(8000, () => {
  console.log('Server is running on http://localhost:8000');
});
```