### PR TITLE
Typescript error fix

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -80,4 +80,4 @@ export function reset(): void;
 export function swaggerise(item: Express | Router): void;
 export function swaggerize(item: Express | Router): void;
 export function validate(): IValid;
-export function ensureValid(): void;
+export function ensureValid(data: any): void;


### PR DESCRIPTION
We need to add argument in "ensureValid" function inside "index.d.ts" otherwise it will give error while compiling typescript.