### PR TITLE
Fixing getting route stack if it was wrapped by Datadog’s dd-trace library

### DIFF
--- a/lib/get-swagger-data-from-route-stack.js
+++ b/lib/get-swagger-data-from-route-stack.js
@@ -16,7 +16,8 @@ module.exports = function getSwaggerDataFromRouteStack(stack, pathPrefix) {
     });
     routerRoutes.forEach(function (middleware) {
         var newPrefix = getPathFromMiddleware(middleware);
-        var subRoutes = getSwaggerDataFromRouteStack(middleware.handle.stack, pathPrefix + newPrefix);
+        var routeStack = getStackFromMiddleware(middleware);
+        var subRoutes = getSwaggerDataFromRouteStack(routeStack, pathPrefix + newPrefix);
         routes = routes.concat(subRoutes);
     });
     return routes;
@@ -49,4 +50,14 @@ function getPathFromMiddleware(middleware) {
     var regEx = new RegExp(_.escapeRegExp("\\/"), 'g');
     result = result.replace(regEx, '/');
     return result;
+}
+
+function getStackFromMiddleware(middleware) {
+    var stack = middleware.handle.stack;
+    // there is a known issue that dd-trace library wraps all of the route handler functions with it’s own function
+    // they store original handle function in _datadog_orig property
+    if (!stack && middleware.handle._datadog_orig) {
+        return _.get(middleware, 'handle._datadog_orig.stack', stack);
+    }
+    return stack;
 }


### PR DESCRIPTION
Hello! Thank's for the library! =)

We have an issue with Datadog’s [dd-trace-js](https://github.com/DataDog/dd-trace-js) library that brakes swagger-spec-express.

Luckily they have a workaround for the [loopback](https://github.com/strongloop/loopback) which we can use to get original handle object from the `_datadog_orig` property:
https://github.com/DataDog/dd-trace-js/blame/12f3dd89bdef0ba13bc467a043b1294b50a91fd2/packages/datadog-plugin-router/src/index.js#L72

It would be greatly appreciated if you take a look and merge it.